### PR TITLE
Adding standard deviation etc of prediction lengths

### DIFF
--- a/gem_metrics/ngrams.py
+++ b/gem_metrics/ngrams.py
@@ -29,8 +29,13 @@ class NGramStats(ReferencelessMetric):
         results = {}
         for data_id, data in [('', predictions.list_tokenized_lower), ('-nopunct', predictions.list_tokenized_lower_nopunct)]:
 
-            results[f'total_length{data_id}'] = sum([len(inst) for inst in data])
-            results[f'mean_pred_length{data_id}'] = np.mean([len(inst) for inst in data])
+            lengths = [len(inst) for inst in data]
+            results[f'total_length{data_id}'] = sum(lengths)
+            results[f'mean_pred_length{data_id}'] = np.mean(lengths)
+            results[f'std_pred_length{data_id}'] = np.std(lengths)
+            results[f'median_pred_length{data_id}'] = np.median(lengths)
+            results[f'min_pred_length{data_id}'] = min(lengths)
+            results[f'max_pred_length{data_id}'] = max(lengths)
 
             last_ngram_freqs = None  # for conditional entropy, we need lower-level n-grams
             for N in [1, 2, 3]:


### PR DESCRIPTION
Doesn't it also make sense to add the standard deviation, median, min, max to see the variation in output lengths? It's a low-cost addition, but provides a more complete set of descriptors.