### PR TITLE
Changing heavy metrics dependencies to an optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GEM-metrics require recent Python 3, virtualenv or similar is recommended. To in
 ```
 git clone https://github.com/GEM-benchmark/GEM-metrics
 cd GEM-metrics
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-heavy.txt
 ```
 
 If you want to just run the metrics from console (and don't need access to the checkout), you can just run:

--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ pip install -r requirements.txt -r requirements-heavy.txt
 
 If you want to just run the metrics from console (and don't need access to the checkout), you can just run:
 ```
-pip install git+https://github.com/GEM-benchmark/GEM-metrics.git
+pip install 'gem-metrics[heavy] @ git+https://github.com/tuetschek/GEM-metrics.git'
 ```
 
 Note that some NLTK stuff may be downloaded upon first run into a subdirectory where the code is located, 
 so make sure you have write access when you run this.
 Also note that all the required Python libraries are around 3 GB in size when installed.
+
+If you don't need trained metrics (BLEURT, BERTScore, NUBIA, QuestEval), you can ignore the “heavy” part, 
+i.e. only install dependencies from `requirements.txt` or only use `gem-metrics` instead of `gem-metrics[heavy]`
+if installing without checkout. That way, your installed libraries will be ~300 MB.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt -r requirements-heavy.txt
 
 If you want to just run the metrics from console (and don't need access to the checkout), you can just run:
 ```
-pip install 'gem-metrics[heavy] @ git+https://github.com/tuetschek/GEM-metrics.git'
+pip install 'gem-metrics[heavy] @ git+https://github.com/GEM-benchmark/GEM-metrics.git'
 ```
 
 Note that some NLTK stuff may be downloaded upon first run into a subdirectory where the code is located, 

--- a/gem_metrics/__init__.py
+++ b/gem_metrics/__init__.py
@@ -9,21 +9,10 @@ import sys
 
 # Data holder classes
 from .texts import Predictions, References, Sources, Submission
-
-# Metric implementations
-from .meteor import Meteor
-from .bertscore import BERTScore
-from .bleu import BLEU
-from .bleurt import BLEURT
-from .rouge import ROUGE
-from .nist import NIST
-from .local_recall import LocalRecall
-from .msttr import MSTTR
-from .ngrams import NGramStats
+# auto-download
 from .data import ensure_download
-from .sari import SARI
-from .nubia import NUBIA
-from .questeval import QuestEval
+# metric types (metrics are imported dynamically)
+from .metric import ReferencedMetric, ReferencelessMetric, SourceAndReferencedMetric
 
 
 def metric_list_to_metric_dict(metric_list: List[str]) -> Dict[str, List]:
@@ -35,48 +24,35 @@ def metric_list_to_metric_dict(metric_list: List[str]) -> Dict[str, List]:
     metric_list = list(set(metric_list))
 
     metric_name_to_metric_class = {
-        'bertscore': BERTScore,
-        'bleu': BLEU,
-        'bleurt': BLEURT,
-        'local_recall': LocalRecall,
-        'meteor': Meteor,
-        'nist': NIST,
-        'rouge': ROUGE,
-        'msttr': MSTTR,
-        'ngram': NGramStats,
-        'sari': SARI,
-        'nubia': NUBIA,
-        'questeval': QuestEval,
-    }
-
-    metric_name_to_metric_type = {
-        'bertscore': 'referenced',
-        'bleu': 'referenced',
-        'bleurt': 'referenced',
-        'local_recall': 'referenced',
-        'meteor': 'referenced',
-        'nist': 'referenced',
-        'rouge': 'referenced',
-        'msttr': 'referenceless',
-        'ngram': 'referenceless',
-        'sari': 'sourced_and_referenced',
-        'nubia': 'referenced',
-        'questeval': 'sourced_and_referenced',
+        'bertscore': 'BERTScore',
+        'bleu': 'BLEU',
+        'bleurt': 'BLEURT',
+        'local_recall': 'LocalRecall',
+        'meteor': 'Meteor',
+        'nist': 'NIST',
+        'rouge': 'ROUGE',
+        'msttr': 'MSTTR',
+        'ngrams': 'NGramStats',
+        'sari': 'SARI',
+        'nubia': 'NUBIA',
+        'questeval': 'QuestEval',
     }
 
     referenced_list, referenceless_list, sourced_and_referenced_list = [], [], []
 
     for metric_name in metric_list:
-        metric_class = metric_name_to_metric_class[metric_name]
-        metric_type = metric_name_to_metric_type[metric_name]
-        if metric_type == 'referenced':
+        # import the appropriate class (e.g.  "from .bertscore import BERTScore")
+        metric_module = __import__(metric_name, globals=globals(), fromlist=[metric_name_to_metric_class[metric_name]], level=1)
+        metric_class = getattr(metric_module, metric_name_to_metric_class[metric_name])
+        # sort the class according to type
+        if issubclass(metric_class, ReferencedMetric):
             referenced_list.append(metric_class)
-        elif metric_type == 'referenceless':
+        elif issubclass(metric_class, ReferencelessMetric):
             referenceless_list.append(metric_class)
-        elif metric_type == 'sourced_and_referenced':
+        elif issubclass(metric_class, SourceAndReferencedMetric):
             sourced_and_referenced_list.append(metric_class)
         else:
-            raise NotImplementedError(f'{metric_type} is not one of [referenced, referenceless, sourced_and_referenced]. Please check the metric_name_to_metric_type dict.')
+            raise NotImplementedError(f'{str(metric_class)} is not one of [referenced, referenceless, sourced_and_referenced]. Please check the metric_name_to_metric_type dict.')
 
     metric_dict = {
         'referenced_metrics': referenced_list,
@@ -294,8 +270,8 @@ def main():
     ap.add_argument('-s', '--sources-file', '--sources', '--srcs', type=str, help='Path to sources JSON file')
     ap.add_argument('-o', '--output-file', type=str, help='Path to output file', default='')
     ap.add_argument('--heavy-metrics', action='store_true', help='Run heavyweight metrics (BERTScore, BLEURT, NUBIA and QuestEval)')
-    ap.add_argument('--metric-list', nargs='+', default=['bleu', 'meteor', 'rouge', 'nist', 'msttr', 'ngram', 'sari', 'local_recall'],
-                    help=('Full metric list default is [bleu, meteor, rouge, nist, msttr, ngram, sari, local_recall]. '
+    ap.add_argument('--metric-list', nargs='+', default=['bleu', 'meteor', 'rouge', 'nist', 'msttr', 'ngrams', 'sari', 'local_recall'],
+                    help=('Full metric list default is [bleu, meteor, rouge, nist, msttr, ngrams, sari, local_recall]. '
                           + 'You can add bertscore, bleurt, nubia and questeval by manually adding them in the command '
                           + 'line argument here, or by using the --heavy-metrics flag'))
     args = ap.parse_args()

--- a/requirements-heavy.txt
+++ b/requirements-heavy.txt
@@ -1,0 +1,4 @@
+nubia-score
+bert_score
+git+https://github.com/google-research/bleurt.git
+git+https://github.com/recitalAI/QuestEval.git@gem#egg=questeval

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
-bert_score
 datasets>=1.2.1
 nltk
 numpy
 rouge-score
 logzero
 pycountry
-git+https://github.com/google-research/bleurt.git
-git+https://github.com/recitalAI/QuestEval.git@gem#egg=questeval
 sacrebleu>=1.5.0
 sacremoses
-nubia-score
+

--- a/setup.py
+++ b/setup.py
@@ -4,28 +4,32 @@ import re
 from setuptools import setup
 from setuptools import find_packages
 
-install_requires = []
-dependency_links = []
 
-for package in [l.strip() for l in open('requirements.txt').readlines()]:
-    if package.startswith('git+'):
-        if "#egg=" not in package:
-            # Intuiting the name by taking last object git url
-            # by taking text without any special char "/@." between "/" and ".git":
-            # example:
-            #   "git+https://github.com/google-research/bleurt.git"
-            # returns "bleurt"
-            pk_name = re.search(r"(?<=/)([^/@.]+)(?=\.git)", package).group(0)
-        else:
-            # Taking the given name after keyword "#egg="
-            # by taking text without any special char "/@." after "#egg=":
-            # example:
-            #   "git+https://github.com/recitalAI/QuestEval.git@gem#egg=questeval"
-            # returns "questeval"
-            pk_name = re.search(r"(?<=#egg=)([^/@.]+)", package).group(0)
-        install_requires.append(f'{pk_name} @ {package}')
-    else:
-        install_requires.append(package)
+def load_packages(fname):
+    packages = []
+    for package in [l.strip() for l in open(fname).readlines()]:
+        if package.startswith('git+'):
+            if "#egg=" not in package:
+                # Intuiting the name by taking last object git url
+                # by taking text without any special char "/@." between "/" and ".git":
+                # example:
+                #   "git+https://github.com/google-research/bleurt.git"
+                # returns "bleurt"
+                pk_name = re.search(r"(?<=/)([^/@.]+)(?=\.git)", package).group(0)
+            else:
+                # Taking the given name after keyword "#egg="
+                # by taking text without any special char "/@." after "#egg=":
+                # example:
+                #   "git+https://github.com/recitalAI/QuestEval.git@gem#egg=questeval"
+                # returns "questeval"
+                pk_name = re.search(r"(?<=#egg=)([^/@.]+)", package).group(0)
+            package = f'{pk_name} @ {package}'
+        packages.append(package)
+    return packages
+
+install_requires = load_packages('requirements.txt')
+extras_require = {'heavy': load_packages('requirements-heavy.txt')}
+
 
 setup(
     name='gem_metrics',
@@ -37,7 +41,8 @@ setup(
     download_url='https://github.com/GEM-benchmark/GEM-metrics.git',
     license='MIT License',
     install_requires=install_requires,
-    dependency_links=dependency_links,
+    dependency_links=[],
+    extras_require=extras_require,
     packages=find_packages(),
     entry_points = {
         'console_scripts': ['gem_metrics=gem_metrics:main']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,10 @@
 import random
 import numpy as np
-import torch
-torch.manual_seed(0)
 random.seed(0)
 np.random.seed(0)
+
+try:
+    import torch
+    torch.manual_seed(0)
+except ImportError as e:
+    pass

--- a/tests/test_bertscore.py
+++ b/tests/test_bertscore.py
@@ -1,5 +1,5 @@
 import unittest
-import gem_metrics
+import gem_metrics.bertscore
 from tests.test_referenced import TestReferencedMetric
 
 class TestBertScore(TestReferencedMetric, unittest.TestCase):

--- a/tests/test_bleu.py
+++ b/tests/test_bleu.py
@@ -1,5 +1,5 @@
 import unittest
-import gem_metrics
+import gem_metrics.bleu
 from tests.test_referenced import TestReferencedMetric
 
 

--- a/tests/test_bleurt.py
+++ b/tests/test_bleurt.py
@@ -1,6 +1,6 @@
 import unittest
 import sys
-import gem_metrics
+import gem_metrics.bleurt
 from tests.test_referenced import TestReferencedMetric
 
 sys.argv = sys.argv[:1]  # ignore unittest flags

--- a/tests/test_local_recall.py
+++ b/tests/test_local_recall.py
@@ -1,5 +1,5 @@
 import unittest
-import gem_metrics
+import gem_metrics.local_recall
 from tests.test_referenced import TestReferencedMetric
 
 class TestLocalRecall(TestReferencedMetric, unittest.TestCase):

--- a/tests/test_meteor.py
+++ b/tests/test_meteor.py
@@ -1,5 +1,5 @@
 import unittest
-import gem_metrics
+import gem_metrics.meteor
 from tests.test_referenced import TestReferencedMetric
 
 class TestMeteor(TestReferencedMetric, unittest.TestCase):

--- a/tests/test_nist.py
+++ b/tests/test_nist.py
@@ -1,5 +1,5 @@
 import unittest
-import gem_metrics
+import gem_metrics.nist
 from tests.test_referenced import TestReferencedMetric
 
 

--- a/tests/test_nubia.py
+++ b/tests/test_nubia.py
@@ -1,5 +1,5 @@
 import unittest
-import gem_metrics
+import gem_metrics.nubia
 from tests.test_referenced import TestReferencedMetric
 
 

--- a/tests/test_questeval.py
+++ b/tests/test_questeval.py
@@ -1,6 +1,6 @@
 import unittest
 import sys
-import gem_metrics
+import gem_metrics.questeval
 from tests.test_sourced_and_referenced import TestSourcedAndReferencedMetric
 
 

--- a/tests/test_rouge.py
+++ b/tests/test_rouge.py
@@ -1,5 +1,5 @@
 import unittest
-import gem_metrics
+import gem_metrics.rouge
 from tests.test_referenced import TestReferencedMetric
 
 class TestRouge(TestReferencedMetric, unittest.TestCase):

--- a/tests/test_sari.py
+++ b/tests/test_sari.py
@@ -1,6 +1,6 @@
 from tests.test_sourced_and_referenced import TestSourcedAndReferencedMetric
 import unittest
-import gem_metrics
+import gem_metrics.sari
 from tests.test_sourced_and_referenced import TestSourcedAndReferencedMetric
 
 


### PR DESCRIPTION
The whole repo can be installed and used without dependencies on BLEURT/BERTScore etc. (i.e. without PyTorch and Tensorflow). This makes the installation much smaller if you don't need these metrics.