### PR TITLE
New version of QuestEval

### DIFF
--- a/gem_metrics/questeval.py
+++ b/gem_metrics/questeval.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import numpy as np
 from .metric import SourceAndReferencedMetric
 from questeval.questeval_metric import QuestEval as QuestEvalMetric
 from logzero import logger
@@ -16,14 +15,10 @@ class QuestEval(SourceAndReferencedMetric):
         self.metric = QuestEvalMetric(
             task=self.task,
             language=self.language,
-            isCuda=True,
         )
 
     def compute(self, predictions, references, sources):
-        # TODO: For better code comprehension, not batched for now. (maybe in future)
-        # TODO: Use cached version (maybe in future)
-        # TODO: only mono reference for now.
-        # Not using references for now, but we will in future.
+        # If task or language is different, we must change QA / QG models for questeval
         if predictions.task != self.task or predictions.language.alpha_2 != self.language:
             self.task = predictions.task
             self.language = predictions.language
@@ -39,24 +34,22 @@ class QuestEval(SourceAndReferencedMetric):
             self.metric = QuestEvalMetric(
                 task=task,
                 language=predictions.language.alpha_2,
-                isCuda=True,
             )
 
-        # If the task is not available, then we give references instead of sources
+        # If the task was not available, then we pass references instead of sources
         local_sources, local_references = sources.untokenized, [[None]] * len(sources.untokenized)
         if self._this_task_is_available is False:
             local_sources, local_references = [None] * len(references.untokenized), references.untokenized
 
-        # Computing scores
-        scores = [
-            self.metric.compute_all(p, source=s, reference=r[0])["scores"]
-            for p, s, r in zip(predictions.untokenized, local_sources, local_references)
-        ]
+        # Computing scores through one batched step
+        scores = self.metric.corpus_questeval(
+            hypothesis=predictions.untokenized,
+            sources=local_sources,
+            list_references=local_references,
+        )
 
         return {
             'questeval': {
-                'precision': np.mean([s["precision"] for s in scores]),
-                'recall': np.mean([s["recall"] for s in scores]),
-                'f1': np.mean([s["fscore"] for s in scores]),
+                "f1": scores["corpus_score"]
             }
         }

--- a/requirements-heavy.txt
+++ b/requirements-heavy.txt
@@ -1,4 +1,4 @@
 nubia-score
 bert_score
 git+https://github.com/google-research/bleurt.git
-questeval
+questeval==0.2.4

--- a/requirements-heavy.txt
+++ b/requirements-heavy.txt
@@ -1,4 +1,4 @@
 nubia-score
 bert_score
 git+https://github.com/google-research/bleurt.git
-git+https://github.com/recitalAI/QuestEval.git@gem#egg=questeval
+questeval

--- a/tests/test_questeval.py
+++ b/tests/test_questeval.py
@@ -1,5 +1,4 @@
 import unittest
-import sys
 import gem_metrics.questeval
 from tests.test_sourced_and_referenced import TestSourcedAndReferencedMetric
 
@@ -9,10 +8,10 @@ class TestQuestEval(TestSourcedAndReferencedMetric, unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.metric = gem_metrics.questeval.QuestEval()
-        self.true_results_basic = {'questeval': {'precision': 0.8430564959433321, 'recall': 0.7523951736176925, 'f1': 0.7977258347805124}}
-        self.true_results_identical_pred_ref = {'questeval': {'precision': 0.8886355747320557, 'recall': 0.8886355747320557, 'f1': 0.8886355747320557}}
-        self.true_results_mismatched_pred_ref = {'questeval': {'precision': 0.23941414190663232, 'recall': 0.2270226373716637, 'f1': 0.23321838963914798}}
-        self.true_results_empty_pred = {'questeval': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0}}
+        self.true_results_basic = {'questeval': {'f1': 0.7226280048489571}}
+        self.true_results_identical_pred_ref = {'questeval': {'f1': 0.877193151248826}}
+        self.true_results_mismatched_pred_ref = {'questeval': {'f1': 0.22809108622648097}}
+        self.true_results_empty_pred = {'questeval': {'f1': 0.0}}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
QuestEval is now available again in GEM Benchmark and (should) work like a charm !

Several improvements are also available thanks to a new version of QuestEval:
- QuestEval is allowing batching, to fully use CPU / GPU power.
- QuestEval is allowing multi references
- QuestEval is using a cache system, allowing to quickly reuse precomputed examples.
- QuestEval is using QA and QG models that have been uploaded to Hugging Face model hub.
- QuestEval is available through Pypi allowing to remove github dependencies in GEM benchmark.
