### PR TITLE
Fixes #51 (Single file mode)

### DIFF
--- a/gem_metrics/__init__.py
+++ b/gem_metrics/__init__.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 from copy import copy
 from dataclasses import dataclass
-from gem_metrics.config import (get_all_datasets, get_language_for_dataset, 
+from gem_metrics.config import (get_all_datasets, get_language_for_dataset,
                                 get_url_for_dataset, get_all_transformation_sets,
                                 get_parent_dataset_for_transformation,
                                 get_all_subpopulation_sets,
@@ -431,8 +431,8 @@ def process_files(config):
     # Single-file mode.
     else:
         outs = Predictions(data)
-        srcs = {}
-        refs = {}
+        srcs = None
+        refs = None
 
         # load references, if available
         if config.references_file is not None:
@@ -521,7 +521,7 @@ def main():
         ),
     )
     ap.add_argument(
-        "--num_threads", type=int, 
+        "--num_threads", type=int,
         help="Number of threads that will be started in parallel.", default=12
     )
     args = ap.parse_args()

--- a/gem_metrics/metric.py
+++ b/gem_metrics/metric.py
@@ -58,7 +58,7 @@ class AbstractMetric:
             for pred_id in predictions.ids:
                 cache_key = (self.__class__.__name__, predictions.filename, pred_id)
                 current_score = cache.get(cache_key, None)
-                    
+
                 if current_score is not None:
                     cached_scores[pred_id] = current_score
                 else:

--- a/gem_metrics/texts.py
+++ b/gem_metrics/texts.py
@@ -23,6 +23,8 @@ class Texts:
             with open(data, "r", encoding="UTF-8") as fh:
                 data = json.load(fh)
                 self.all_data = data
+            if isinstance(data, dict) and "values" in data:
+                self.all_data = data["values"]
         else:
             self.filename = data.get("filename")
             self.all_data = data["values"]
@@ -110,7 +112,7 @@ class Texts:
         Args:
             id_list: ordered ID list of the associated reference file.
         """
-        if not self.ids is None:
+        if self.ids is not None and id_list is not None:
             # Is the ID list set, but in a different order?
             if self.ids != id_list:
                 logger.info(
@@ -127,7 +129,11 @@ class Texts:
         else:
             # In this case we simply assume that the predictions were in order.
             # There is no other way to test for this.
-            self.ids = id_list
+            if id_list is not None:
+                self.ids = id_list
+            # when everything is None, we just make caching work
+            elif self.ids is None:
+                self.ids = ["generated-%05d" % i for i in range(len(self))]
 
     def __len__(self):
         return len(self.data)
@@ -140,6 +146,8 @@ class Predictions(Texts):
         # Task is used in QuestEval metric to select the correct model.
         self.task = task
         super().__init__(data_key="generated", data=data, language=language)
+        #if self.ids is None:
+        #    self.ids = ["unk-%05d" % i for i in range(len(self))]
 
 
 class References(Texts):


### PR DESCRIPTION
This should fix #51 -- it creates fake instance IDs when there are no ids for either references or system outputs, so that caching works properly. Also initializes references/sources to `None` instead of `{}` so that only appropriate metrics are computed.

@sebastianGehrmann could you please check that it doesn't break anything else?