### PR TITLE
Change cached_property and union operator for backwards compatibility

### DIFF
--- a/gem_metrics/__init__.py
+++ b/gem_metrics/__init__.py
@@ -234,8 +234,10 @@ def process_submission(
         outs_ds = outs.predictions_for(dataset)
         refs_ds = refs.get(dataset, None)
         srcs_ds = srcs.get(dataset, None)
-        shared_dict[dataset] = shared_dict[dataset] | compute(
-            outs_ds, refs_ds, srcs_ds, serial_metric_dict, cache, dataset
+        shared_dict[dataset].update(
+            compute(
+                outs_ds, refs_ds, srcs_ds, serial_metric_dict, cache, dataset
+            )
         )
 
     return dict(shared_dict)

--- a/gem_metrics/metric.py
+++ b/gem_metrics/metric.py
@@ -86,7 +86,8 @@ class AbstractMetric:
 
         if self.support_caching():
             # Combine them back and reshuffle.
-            scores = cached_scores | computed_scores
+            cached_scores.update(computed_scores)
+            scores = cached_scores
             scores_ordered = [scores[pred_id] for pred_id in original_order]
             # Aggregate individual scores.
             aggregated_score = self._aggregate_scores(scores_ordered)

--- a/gem_metrics/texts.py
+++ b/gem_metrics/texts.py
@@ -53,12 +53,14 @@ class Texts:
         # tokenize & keep a list and a whitespace version
         self.tokenize_func = default_tokenize_func(self.language)
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache()
     def untokenized(self):
         """Return list of (lists of) untokenized strings."""
         return self.data
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache()
     def _tokenized(self):
         """Return list of (lists of) untokenized strings."""
         if self.multi_ref:
@@ -66,7 +68,8 @@ class Texts:
         else:
             return [self.tokenize_func(ref) for ref in self.data]
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache()
     def whitespace_tokenized(self):
         """Return list of (lists of) tokenized strings (tokens separated by space)."""
         if self.multi_ref:
@@ -74,12 +77,14 @@ class Texts:
         else:
             return [" ".join(ref) for ref in self._tokenized]
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache()
     def list_tokenized(self):
         """Return list of (lists of) lists of tokens."""
         return self._tokenized
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache()
     def list_tokenized_lower(self):
         """Return list of (lists of) lists of tokens, lowercased."""
         if self.multi_ref:
@@ -89,7 +94,8 @@ class Texts:
         else:
             return [[w.lower() for w in ref] for ref in self._tokenized]
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache()
     def list_tokenized_lower_nopunct(self):
         """Return list of (lists of) lists of tokens, lowercased, excluding punctuation."""
         if self.multi_ref:


### PR DESCRIPTION
Currently the library requires Python >= 3.9 due to using functools.cached_property and dict union. This creates a problem for users who can't easily change versions/environments (eg Colab/Kaggle). 

(also see: https://github.com/GEM-benchmark/GEM-metrics/issues/61)

This PR makes the library backwards compatible and has been tested on 3.7.