### PR TITLE
Use reference dataset on the Hugging Face Hub

### DIFF
--- a/gem_metrics/config.py
+++ b/gem_metrics/config.py
@@ -117,7 +117,7 @@ for dataset_name, settings in _SUPPORTED_DATASETS.items():
         sanitized_dataset_name = dataset_name.replace("_val", "_validation")
     else:    
         sanitized_dataset_name = dataset_name
-    settings['url'] = f"https://huggingface.co/datasets/lewtun/gem-references/resolve/main/{sanitized_dataset_name}.json"
+    settings['url'] = f"https://huggingface.co/datasets/GEM/references/resolve/main/{sanitized_dataset_name}.json"
 
 # If you want to add a custom dataset / url, you can add it here.
 # Just ensure that your entry has `language`, `task`, and `url` set.

--- a/gem_metrics/config.py
+++ b/gem_metrics/config.py
@@ -117,7 +117,7 @@ for dataset_name, settings in _SUPPORTED_DATASETS.items():
         sanitized_dataset_name = dataset_name.replace("_val", "_validation")
     else:    
         sanitized_dataset_name = dataset_name
-    settings['url'] = f"https://github.com/GEM-benchmark/GEM-metrics/releases/download/data/{sanitized_dataset_name}.json"
+    settings['url'] = f"https://huggingface.co/datasets/lewtun/gem-references/resolve/main/{sanitized_dataset_name}.json"
 
 # If you want to add a custom dataset / url, you can add it here.
 # Just ensure that your entry has `language`, `task`, and `url` set.


### PR DESCRIPTION
This PR updates the URL for the reference datasets to point to the [`GEM/references`](https://huggingface.co/datasets/GEM/references) repository on the Hugging Face Hub. 

As discussed with @sebastianGehrmann, this new URL will act as the central source of truth for the GEM references going forward.

Note that the `GEM/references` repository is _public_ (i.e. visible by anyone). If we want to make it _private_ we'll need to include an API token in the HTTP call to access each of the datasets.

Before merging we should check:

- [x] All datasets have been successfully replicated from GitHub to the Hugging Face Hub.
- [x] All Hugging Face Hub datasets have been converted to JSON and validated against the original GitHub files. See [here](https://huggingface.co/datasets/GEM/references/blob/main/convert_datasets_to_json.py) for a script that was used to convert and validate the MLSUM references.