### PR TITLE
Adding ability to run on-demand unit tests

### DIFF
--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -1,0 +1,32 @@
+name: On-Demand Unit Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      files:
+        description: "Files with unittests that should be run"
+        required: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+    - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+    - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+
+    - name: Test with unittest
+      run: |
+        python -m unittest ${{ github.event.inputs.files }}

--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -13,19 +13,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
+      with:
+        distribution: 'temurin'
+        java-version: '17'
     - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
 
     - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade pip setuptools wheel
-          pip install -r requirements.txt
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
+        pip install -r requirements.txt
 
     - name: Test with unittest
       run: |

--- a/tests/test_bleurt.py
+++ b/tests/test_bleurt.py
@@ -2,6 +2,7 @@ import unittest
 import sys
 import gem_metrics.bleurt
 from tests.test_referenced import TestReferencedMetric
+from tests.utils import get_testing_device
 
 sys.argv = sys.argv[:1]  # ignore unittest flags
 
@@ -9,7 +10,8 @@ sys.argv = sys.argv[:1]  # ignore unittest flags
 class TestBluert(TestReferencedMetric, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.metric = gem_metrics.bleurt.BLEURT()
+        device = get_testing_device()
+        self.metric = gem_metrics.bleurt.BLEURT(device=device)
         self.metric._initialize()
         self.true_results_basic = {"bleurt": -0.018821040789286297}
         self.true_results_identical_pred_ref = {"bleurt": 0.941490113735199}

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -1,12 +1,14 @@
 import unittest
 import gem_metrics.prism
 from tests.test_referenced import TestReferencedMetric
+from tests.utils import get_testing_device
 
 
 class TestPrism(TestReferencedMetric, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.metric = gem_metrics.prism.Prism(device=-1)
+        device = get_testing_device()
+        self.metric = gem_metrics.prism.Prism(device=device)
         self.true_results_basic = {"prism": -1.7404}
         self.true_results_identical_pred_ref = {"prism": -0.229}
         self.true_results_mismatched_pred_ref = {"prism": -6.62654}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
 import json
+import os
 from numpy import long, ndarray
 from gem_metrics.texts import Texts
+from typing import List, Tuple
 
 
 def assertDeepAlmostEqual(test_case, expected, actual, *args, **kwargs):
@@ -62,3 +64,19 @@ def read_test_data(pth: str, data_type: Texts) -> Texts:
     """
     with open(pth, "r") as fin:
         return data_type(json.load(fin))
+
+
+def get_testing_device() -> int:
+    """Get the device ID that unit tests should be run on.
+
+    The device ID can be set via the TEST_DEVICE environment parameter.
+    -1 should be used for CPU and >= 0 for GPU. If the environment variable
+    is not set, -1 is returned by default.
+
+    Returns:
+        int: The device ID
+    """
+    key = "TEST_DEVICE"
+    if key in os.environ:
+        return int(os.environ[key])
+    return -1


### PR DESCRIPTION
This PR adds
- A new Github Action that will let you manually run unit tests without a push/PR
- A method to get the device ID that unit tests should be run on

This will allow us to run Docker metrics with Github Actions as necessary on the CPU. The Docker metrics would be expensive to run every time, so with this PR we could manually run the unit tests for a new Docker metric when its PR is submitted.

I am not actually sure how to test to make sure the new Action is working. I do not see it available for running on-demand on the Actions page. I don't know if this is because it has to be in the main branch first, if I don't have the required permissions, or if there's some mistake in the config. I vaguely remember not being able to see the Action until it was merged when I implemented this in Repro.