### PR TITLE
Fixing aggregation function

### DIFF
--- a/gem_metrics/metric.py
+++ b/gem_metrics/metric.py
@@ -28,7 +28,7 @@ class AbstractMetric:
             )
         elif isinstance(score_list[0], dict):
             l1_keys = list(score_list[0].keys())
-            if isinstance(list(score_list[0].values())[0], float):
+            if isinstance(list(score_list[0].values())[0], (float, int)):
                 return {
                     key: round(np.mean([score[key] for score in score_list]), 5)
                     for key in l1_keys
@@ -44,10 +44,9 @@ class AbstractMetric:
                     }
                     for key1 in l1_keys
                 }
-        else:
-            return ValueError(
-                "Please add to this function an aggregator for your data format."
-            )
+        return ValueError(
+            "Please add to this function an aggregator for your data format."
+        )
 
     def compute_cached(self, cache, predictions: Predictions, *args):
         """Loops through the predictions to check for cache hits before computing."""


### PR DESCRIPTION
I ran into a case where a metric returned a dict that mapped from a `str` to an `int`. No aggregation function matched because it isn't type `float`. The method was returning `None` and it was hard to find out why.

This PR enables aggregating over `int`s and raises an error if no aggregation function is found instead of returning `None`