### PR TITLE
Adding Two Diversity Metrics: TTR and Yule's I-Measure

### DIFF
--- a/gem_metrics/__init__.py
+++ b/gem_metrics/__init__.py
@@ -52,6 +52,8 @@ def metric_list_to_metric_dict(metric_list: List[str]) -> Dict[str, List]:
         "questeval": "QuestEval",
         "prism": "Prism",
         "ter": "TER",
+        "ttr": "TTR",
+        "yules_i": "Yules_I",
     }
 
     referenced_list, referenceless_list, sourced_and_referenced_list = [], [], []
@@ -511,10 +513,12 @@ def main():
             "ngrams",
             "sari",
             "ter",
+            "ttr",
+            "yules_i",
             "local_recall",
         ],
         help=(
-            "Full metric list default is [bleu, meteor, rouge, nist, msttr, ngram, sari, ter, local_recall]. "
+            "Full metric list default is [bleu, meteor, rouge, nist, msttr, ngram, sari, ter, ttr, yules_i, local_recall]. "
             + "You can add bertscore, bleurt, nubia and questeval by manually adding them in the command "
             + "line argument here, or by using the --heavy-metrics flag"
         ),

--- a/gem_metrics/__init__.py
+++ b/gem_metrics/__init__.py
@@ -54,6 +54,9 @@ def metric_list_to_metric_dict(metric_list: List[str]) -> Dict[str, List]:
         "ter": "TER",
         "ttr": "TTR",
         "yules_i": "Yules_I",
+        "wer":"WER",
+        "cider": "CIDER",
+        "moverscore": "MoverScore",
     }
 
     referenced_list, referenceless_list, sourced_and_referenced_list = [], [], []

--- a/gem_metrics/ttr.py
+++ b/gem_metrics/ttr.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from numpy import NaN
 from .metric import ReferencelessMetric
 from .texts import Predictions
 
@@ -41,5 +42,8 @@ class TTR(ReferencelessMetric):
 
     def compute(self, cache, predictions: Predictions) -> Dict:
         total, vocabulary = self.get_vocabulary(predictions.untokenized)
-        score = len(vocabulary)/total
+        if total == 0:
+            score = NaN
+        else:
+            score = len(vocabulary)/total
         return {"ttr": round(score, 5)}

--- a/gem_metrics/ttr.py
+++ b/gem_metrics/ttr.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+from .metric import ReferencelessMetric
+from .texts import Predictions
+
+from typing import Dict
+
+
+class TTR(ReferencelessMetric):
+    """Implements Type to Token Ratio (TTR) as described in 
+    "Machine Translationese: Effects of Algorithmic Bias on Linguistic
+    Complexity in Machine Translation", Vanmassenhove et al., EACL 2021.
+
+    TTR presents the ratio of the total number of different words (types)
+    to the total number of words (tokens). 
+    Higher TTR indicates a higher degree of lexical diversity.
+    This is implemented below using a simple dictionary counter.    
+    """
+
+    def support_caching(self):
+        # corpus-level, so individual examples can't be aggregated.
+        return False
+
+    def get_vocabulary(self, sentence_array):
+        """Compute vocabulary
+        :param sentence_array: a list of sentences
+        :returns: a list of tokens
+        """
+        data_vocabulary = {}
+        total = 0
+        
+        for sentence in sentence_array:
+            for token in sentence.strip().split():
+                if token not in data_vocabulary:
+                    data_vocabulary[token] = 1
+                else:
+                    data_vocabulary[token] += 1
+                total += 1
+                
+        return total, data_vocabulary
+
+    def compute(self, cache, predictions: Predictions) -> Dict:
+        total, vocabulary = self.get_vocabulary(predictions.untokenized)
+        score = len(vocabulary)/total
+        return {"ttr": round(score, 5)}

--- a/gem_metrics/yules_i.py
+++ b/gem_metrics/yules_i.py
@@ -14,9 +14,13 @@ class Yules_I(ReferencelessMetric):
     Complexity in Machine Translation", Vanmassenhove et al., EACL 2021.
 
     Yule’s characteristic constant (Yule’s K) measures constancy of text 
-    as the repetitiveness of vocabulary. Yule’s K and its inverse Yule’s I 
-    (implemented here) are considered to be more resilient to fluctuations
+    as the repetitiveness of vocabulary. The larger the Yule's K, 
+    the less rich the vocabulary is. Yule’s K and its inverse Yule’s I 
+    (implemented here) are considered to be more resilient to fluctuations 
     related to text length than TTR.
+    For a history of constancy measures of text, see Tanaka-Ishii et al, 
+    "Computational Constancy Measures of Texts—Yule's K and Rényi's Entropy".
+    The implementation follows equation (1) in the above paper.
     """
 
     def support_caching(self):
@@ -50,12 +54,12 @@ class Yules_I(ReferencelessMetric):
         _, vocabulary = self.get_vocabulary(predictions.untokenized)
 
         M1 = float(len(vocabulary))
-        M2 = sum([len(list(g))*(freq**2) for freq,g in itertools.groupby(sorted(vocabulary.values()))])
+        M2 = sum([len(list(g))*(freq**2) for freq, g in itertools.groupby(sorted(vocabulary.values()))])
         
-        score = (M1*M1)/(M2-M1)
+        if M2-M1 == 0:
+            score = 0.0
+        else:
+            score = (M1*M1)/(M2-M1)
 
-        try:
-            return {"yules_i": round(score, 5)}
-        except ZeroDivisionError:
-            return {"yules_i": 0.0}
-
+        return {"yules_i": round(score, 3)}
+        

--- a/gem_metrics/yules_i.py
+++ b/gem_metrics/yules_i.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import itertools
+
+from .metric import ReferencelessMetric
+from .texts import Predictions
+
+from typing import Dict
+
+
+class Yules_I(ReferencelessMetric):
+    """Yules I measure (Yules_I) as described in 
+    "Machine Translationese: Effects of Algorithmic Bias on Linguistic
+    Complexity in Machine Translation", Vanmassenhove et al., EACL 2021.
+
+    Yule’s characteristic constant (Yule’s K) measures constancy of text 
+    as the repetitiveness of vocabulary. Yule’s K and its inverse Yule’s I 
+    (implemented here) are considered to be more resilient to fluctuations
+    related to text length than TTR.
+    """
+
+    def support_caching(self):
+        # corpus-level, so individual examples can't be aggregated.
+        return False
+
+    def get_vocabulary(self, sentence_array):
+        """Compute vocabulary
+        :param sentence_array: a list of sentences
+        :returns: a list of tokens
+        """
+        data_vocabulary = {}
+        total = 0
+        
+        for sentence in sentence_array:
+            for token in sentence.strip().split():
+                if token not in data_vocabulary:
+                    data_vocabulary[token] = 1
+                else:
+                    data_vocabulary[token] += 1
+                total += 1
+                
+        return total, data_vocabulary
+
+    def compute(self, cache, predictions: Predictions) -> Dict:
+
+        """ Computing Yules I measure
+        :param sentences: dictionary with all words and their frequencies
+        :returns: Yules I (the inverse of yule's K measure) (float) - the higher the better
+        """
+        _, vocabulary = self.get_vocabulary(predictions.untokenized)
+
+        M1 = float(len(vocabulary))
+        M2 = sum([len(list(g))*(freq**2) for freq,g in itertools.groupby(sorted(vocabulary.values()))])
+        
+        score = (M1*M1)/(M2-M1)
+
+        try:
+            return {"yules_i": round(score, 5)}
+        except ZeroDivisionError:
+            return {"yules_i": 0.0}
+

--- a/tests/test_ttr.py
+++ b/tests/test_ttr.py
@@ -1,0 +1,71 @@
+import unittest
+import math
+from gem_metrics.ttr import TTR
+from gem_metrics.texts import Predictions
+from tests.test_referenceless import TestReferenceLessMetric
+from tests.inputs import TestData
+from tests.utils import assertDeepAlmostEqual
+
+
+class TestTTR(TestReferenceLessMetric, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.metric = TTR()
+
+    def test_ttr_metric_basic(self):
+        """Tests for the base case."""
+
+        expected_metrics = {
+            "ttr": 0.72414
+        }
+
+        calculated_metrics = self.metric.compute({}, TestData.predictions)
+        assertDeepAlmostEqual(self, expected_metrics, calculated_metrics)
+
+    def test_ttr_metric_empty(self):
+        """Tests with list of empty sentences. """
+        text = ["", ""]
+
+        calculated_metrics = self.metric.compute(
+            {},
+            Predictions({"values": text})
+        )
+
+        self.assertTrue(math.isnan(calculated_metrics["ttr"]))
+
+    def test_ttr_disjoint_tokens(self):
+        """Tests for TTR with disjoint tokens. The TTR should be 1.
+        """
+        text = [
+            "one two three four five six seven eight nine ten",
+            "eleven twelve thirteen fourteen fifteen sixteen",
+        ]
+
+        metric = TTR()
+        calculated_metrics = metric.compute(
+            {},
+            Predictions({"values": text})
+        )
+        self.assertAlmostEqual(calculated_metrics[f"ttr"], 1)
+
+    def test_ttr_identical_tokens(self):
+        """Tests for TTR with identical tokens.
+        As the tokens are identical, the TTR be 1 / total_tokens (there is only one _type_ of token)
+        """
+        text = [
+            "token token token token token token token token token token token token token",
+            "token token token token token token token token token token token token token",
+        ]
+
+        metric = TTR()
+        calculated_metrics = metric.compute(
+            {},
+            Predictions({"values": text})
+        )
+        self.assertAlmostEqual(
+            calculated_metrics[f"ttr"], round(1/sum(len(s.split()) for s in text), 5)
+        )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yules_i.py
+++ b/tests/test_yules_i.py
@@ -1,0 +1,78 @@
+import unittest
+from gem_metrics.yules_i import Yules_I
+from gem_metrics.texts import Predictions
+from tests.test_referenceless import TestReferenceLessMetric
+from tests.inputs import TestData
+from tests.utils import assertDeepAlmostEqual
+
+class TestYULES_I(TestReferenceLessMetric, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.metric = Yules_I()
+
+    def test_yules_i_metric_basic(self):
+        """Tests for the base case."""
+        expected_metrics = {
+            "yules_i": 16.962
+        }
+
+        calculated_metrics = self.metric.compute({}, TestData.predictions)
+        assertDeepAlmostEqual(self, expected_metrics, calculated_metrics)
+
+    def test_yules_i_metric_empty(self):
+        """Tests with empty inputs"""
+        text = ["", ""]
+
+        calculated_metrics = self.metric.compute(
+            {},
+            Predictions({"values": text})
+        )
+
+        self.assertAlmostEqual(calculated_metrics[f"yules_i"], 0)
+
+    def test_yules_i_disjoint_tokens(self):
+        """Tests for Yules_I with disjoint tokens.
+        """
+        text = [
+            "one two three four five six seven eight nine ten",
+            "eleven twelve thirteen fourteen fifteen sixteen",
+        ]
+        metric = Yules_I()
+        calculated_metrics = metric.compute(
+            {},
+            Predictions({"values": text})
+        )
+        self.assertAlmostEqual(calculated_metrics[f"yules_i"], 0.0)
+
+    def test_yules_i_mixed_tokens(self):
+        """Tests for Yules_I with disjoint tokens.
+        """
+        text = [
+            "one two one two three four five six five six",
+            "six seven eight eight nine ten ten ten ten",
+        ]
+        metric = Yules_I()
+        calculated_metrics = metric.compute(
+            {},
+            Predictions({"values": text})
+        )
+        self.assertAlmostEqual(calculated_metrics[f"yules_i"], 2.857)
+
+    def test_yules_i_identical_tokens(self):
+        """Tests for Yules_I with identical tokens (low diversity).
+        """
+        text = [
+            "token token token token token token token token token token token token token",
+            "token token token token token token token token token token token token token",
+        ]
+        metric = Yules_I()
+        calculated_metrics = metric.compute(
+            {},
+            Predictions({"values": text})
+        )
+        self.assertAlmostEqual(
+            calculated_metrics[f"yules_i"], 0.001
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds two new metrics to GEM: TTR and Yule's I-Measure, as described in "Machine Translationese: Effects of Algorithmic Bias on Linguistic Complexity in Machine Translation", Vanmassenhove et al., EACL 2021.

1. TTR (Type to Token Ratio) presents the ratio of the total number of different words (types) to the total number of words (tokens). Higher TTR indicates a higher degree of lexical diversity.
2. Yule’s characteristic constant (Yule’s K) measures constancy of text as the repetitiveness of vocabulary. Yule’s K and its inverse Yule’s I measure (implemented here) are considered to be more resilient to fluctuations related to text length than TTR.

Please let me know if any changes would be helpful prior to the integration. Thanks.