### PR TITLE
Better docs & better use as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If you don't need trained metrics (BLEURT, BERTScore, NUBIA, QuestEval), you can
 i.e. only install dependencies from `requirements.txt` or only use `gem-metrics` instead of `gem-metrics[heavy]`
 if installing without checkout. That way, your installed libraries will be ~300 MB.
 
-Usage
------
+Script Usage
+------------
 
 To compute all default metrics for a file, run:
 ```
@@ -46,6 +46,68 @@ Use `./run_metrics.py -h` to see all available options.
 
 By default, the “heavy” metrics (BERTScore, BLEURT, NUBIA and QuestEval) aren't computed. Use `--heavy-metrics` to compute them.
 
+
+Library Usage
+-------------
+
+You can compute metrics for the same JSON format as shown in [`test_data`](test_data/), or you can work 
+with plain lists of texts (or lists of lists of texts in the case of multi-reference data).
+
+Import GEM-metrics as a library:
+```
+import gem_metrics
+```
+
+To load data from JSON files:
+```
+preds = gem_metrics.texts.Predictions('path/to/pred-file.json')
+refs = gem_metrics.texts.References('path/to/ref-file.json')
+```
+
+To prepare plain lists (assuming the same order):
+```
+preds = gem_metrics.texts.Predictions(list_of_predictions)
+refs = gem_metrics.texts.References(list_of_references)  # input may be list of lists for multi-ref
+```
+
+Then compute the desired metrics:
+```
+result = gem_metrics.compute(preds, refs, metrics_list=['bleu', 'rouge'])  # add list of desired metrics here
+```
+
+
+List of supported metrics
+-------------------------
+
+Referenceless:
+
+* `local_recall` -- LocalRecall
+* `msttr` -- MSTTR
+* `ngrams` -- n-gram statistics
+* `ttr` -- TTR
+
+
+Reference-based:
+
+* `bertscore` -- BERTScore (heavy)
+* `bleu` -- BLEU
+* `bleurt` -- BLEURT (heavy)
+* `chrf` -- CHRF
+* `cider` -- CIDER
+* `meteor` -- Meteor (heavy)
+* `moverscore` -- MoverScore (heavy)
+* `nist` -- NIST
+* `nubia` -- NUBIA (heavy)
+* `prism` -- Prism
+* `questeval` -- QuestEval (heavy)
+* `rouge` -- ROUGE
+* `ter` -- TER
+* `wer` -- WER
+* `yules_i` -- Yules_I
+
+Source + reference based:
+
+* `sari` -- SARI
 
 License
 -------


### PR DESCRIPTION
* Better docs, with library/script use documented + list of metrics
* Library use: allow `metrics_list` in `compute()`, create ad-hoc IDs if no IDs supplied
* Library use: allow bare lists of items in `Predictions`/`References`, allow single references (plain list of strings -- convert to list of lists automatically)