### PR TITLE
Rename Hugging Face Hub path

### DIFF
--- a/gem_metrics/config.py
+++ b/gem_metrics/config.py
@@ -117,6 +117,7 @@ for dataset_name, settings in _SUPPORTED_DATASETS.items():
         sanitized_dataset_name = dataset_name.replace("_val", "_validation")
     else:    
         sanitized_dataset_name = dataset_name
+    # The Hugging Face Hub has a limit of 2,000 files per folder, so we store each reference in a separate folder.
     settings['url'] = f"https://huggingface.co/datasets/GEM/references/resolve/main/{sanitized_dataset_name}/{sanitized_dataset_name}.json"
 
 # If you want to add a custom dataset / url, you can add it here.

--- a/gem_metrics/config.py
+++ b/gem_metrics/config.py
@@ -117,7 +117,7 @@ for dataset_name, settings in _SUPPORTED_DATASETS.items():
         sanitized_dataset_name = dataset_name.replace("_val", "_validation")
     else:    
         sanitized_dataset_name = dataset_name
-    settings['url'] = f"https://huggingface.co/datasets/GEM/references/resolve/main/{sanitized_dataset_name}.json"
+    settings['url'] = f"https://huggingface.co/datasets/GEM/references/resolve/main/{sanitized_dataset_name}/{sanitized_dataset_name}.json"
 
 # If you want to add a custom dataset / url, you can add it here.
 # Just ensure that your entry has `language`, `task`, and `url` set.


### PR DESCRIPTION
This PR tweaks the path to download the references from the Hugging Face Hub, so that each file is stored in a separate folder, e.g.:

```
~/dataset_name/dataset_name.json
```

This is needed because dataset repositories have a limit of 2k files per folder, and we exceeded this limit on a recent extraction of references I performed.

cc @sebastianGehrmann 